### PR TITLE
feat: add HA Ingress support via dynamic BASE_PATH routing

### DIFF
--- a/components/tigo_server/tigo_web_server.cpp
+++ b/components/tigo_server/tigo_web_server.cpp
@@ -2050,11 +2050,11 @@ void TigoWebServer::get_dashboard_html(PSRAMString& html) {
       </div>
     </div>
     <div class="nav">
-      <a href="/" class="active">Dashboard</a>
-      <a href="/nodes">Node Table</a>
-      <a href="/status">ESP32 Status</a>
-      <a href="/yaml">YAML Config</a>
-      <a href="/cca">CCA Info</a>
+      <a href="#" id="nav-dashboard" class="active">Dashboard</a>
+      <a href="#" id="nav-nodes">Node Table</a>
+      <a href="#" id="nav-status">ESP32 Status</a>
+      <a href="#" id="nav-yaml">YAML Config</a>
+      <a href="#" id="nav-cca">CCA Info</a>
     </div>
   </div>
   
@@ -2111,16 +2111,26 @@ void TigoWebServer::get_dashboard_html(PSRAMString& html) {
   <script>
     // API Token configuration
     const API_TOKEN = ")html" + api_token_ + R"html(";
-    
+
+    // Detect ingress base path for HA ingress compatibility
+    function getBasePath() {
+      const path = window.location.pathname;
+      const lastSlash = path.lastIndexOf('/');
+      return path.substring(0, lastSlash + 1);
+    }
+    const BASE_PATH = getBasePath();
+
     // Fetch wrapper that includes authorization header if token is set
     async function apiFetch(url, options = {}) {
       if (API_TOKEN) {
         options.headers = options.headers || {};
         options.headers['Authorization'] = 'Bearer ' + API_TOKEN;
       }
-      return fetch(url, options);
+      // Prefix with BASE_PATH for HA ingress compatibility
+      const fullUrl = BASE_PATH + url.replace(/^\//, '');
+      return fetch(fullUrl, options);
     }
-    
+
     // Temperature unit management
     let useFahrenheit = localStorage.getItem('tempUnit') === 'F';
     
@@ -2212,6 +2222,12 @@ void TigoWebServer::get_dashboard_html(PSRAMString& html) {
     let invertersData = { inverters: [] }; // Cache inverter config (static, only changes on reboot)
     
     document.addEventListener('DOMContentLoaded', () => {
+      // Set nav links relative to base path (HA ingress compatibility)
+      document.getElementById('nav-dashboard').href = BASE_PATH;
+      document.getElementById('nav-nodes').href = BASE_PATH + 'nodes';
+      document.getElementById('nav-status').href = BASE_PATH + 'status';
+      document.getElementById('nav-yaml').href = BASE_PATH + 'yaml';
+      document.getElementById('nav-cca').href = BASE_PATH + 'cca';
       applyTheme();
       document.getElementById('temp-toggle').textContent = useFahrenheit ? '°C' : '°F';
       // Check for new releases
@@ -2724,11 +2740,11 @@ void TigoWebServer::get_node_table_html(PSRAMString& html) {
       </div>
     </div>
     <div class="nav">
-      <a href="/">Dashboard</a>
-      <a href="/nodes" class="active">Node Table</a>
-      <a href="/status">ESP32 Status</a>
-      <a href="/yaml">YAML Config</a>
-      <a href="/cca">CCA Info</a>
+      <a href="#" id="nav-dashboard">Dashboard</a>
+      <a href="#" id="nav-nodes" class="active">Node Table</a>
+      <a href="#" id="nav-status">ESP32 Status</a>
+      <a href="#" id="nav-yaml">YAML Config</a>
+      <a href="#" id="nav-cca">CCA Info</a>
     </div>
   </div>
   
@@ -2765,16 +2781,26 @@ void TigoWebServer::get_node_table_html(PSRAMString& html) {
   <script>
     // API Token configuration
     const API_TOKEN = ")html" + api_token_ + R"html(";
-    
+
+    // Detect ingress base path for HA ingress compatibility
+    function getBasePath() {
+      const path = window.location.pathname;
+      const lastSlash = path.lastIndexOf('/');
+      return path.substring(0, lastSlash + 1);
+    }
+    const BASE_PATH = getBasePath();
+
     // Fetch wrapper that includes authorization header if token is set
     async function apiFetch(url, options = {}) {
       if (API_TOKEN) {
         options.headers = options.headers || {};
         options.headers['Authorization'] = 'Bearer ' + API_TOKEN;
       }
-      return fetch(url, options);
+      // Prefix with BASE_PATH for HA ingress compatibility
+      const fullUrl = BASE_PATH + url.replace(/^\//, '');
+      return fetch(fullUrl, options);
     }
-    
+
     // Dark mode
     let darkMode = localStorage.getItem('darkMode') === 'true';
     
@@ -2796,6 +2822,13 @@ void TigoWebServer::get_node_table_html(PSRAMString& html) {
     
     // Apply theme on load
     applyTheme();
+
+    // Set nav links relative to base path (HA ingress compatibility)
+    document.getElementById('nav-dashboard').href = BASE_PATH;
+    document.getElementById('nav-nodes').href = BASE_PATH + 'nodes';
+    document.getElementById('nav-status').href = BASE_PATH + 'status';
+    document.getElementById('nav-yaml').href = BASE_PATH + 'yaml';
+    document.getElementById('nav-cca').href = BASE_PATH + 'cca';
     
     async function exportNodeTable() {
       try {
@@ -3034,11 +3067,11 @@ void TigoWebServer::get_esp_status_html(PSRAMString& html) {
       </div>
     </div>
     <div class="nav">
-      <a href="/">Dashboard</a>
-      <a href="/nodes">Node Table</a>
-      <a href="/status" class="active">ESP32 Status</a>
-      <a href="/yaml">YAML Config</a>
-      <a href="/cca">CCA Info</a>
+      <a href="#" id="nav-dashboard">Dashboard</a>
+      <a href="#" id="nav-nodes">Node Table</a>
+      <a href="#" id="nav-status" class="active">ESP32 Status</a>
+      <a href="#" id="nav-yaml">YAML Config</a>
+      <a href="#" id="nav-cca">CCA Info</a>
     </div>
   </div>
   
@@ -3184,19 +3217,29 @@ void TigoWebServer::get_esp_status_html(PSRAMString& html) {
   <script>
     // API Token configuration
     const API_TOKEN = ")html" + api_token_ + R"html(";
-    
+
+    // Detect ingress base path for HA ingress compatibility
+    function getBasePath() {
+      const path = window.location.pathname;
+      const lastSlash = path.lastIndexOf('/');
+      return path.substring(0, lastSlash + 1);
+    }
+    const BASE_PATH = getBasePath();
+
     // Fetch wrapper that includes authorization header if token is set
     async function apiFetch(url, options = {}) {
       if (API_TOKEN) {
         options.headers = options.headers || {};
         options.headers['Authorization'] = 'Bearer ' + API_TOKEN;
       }
-      return fetch(url, options);
+      // Prefix with BASE_PATH for HA ingress compatibility
+      const fullUrl = BASE_PATH + url.replace(/^\//, '');
+      return fetch(fullUrl, options);
     }
-    
+
     // Dark mode support
     let darkMode = localStorage.getItem('darkMode') === 'true';
-    
+
     // Temperature unit toggle
     let useFahrenheit = localStorage.getItem('tempUnit') === 'F';
     
@@ -3274,6 +3317,13 @@ void TigoWebServer::get_esp_status_html(PSRAMString& html) {
     // Apply theme and temp toggle on page load
     applyTheme();
     document.getElementById('temp-toggle').textContent = useFahrenheit ? '°C' : '°F';
+
+    // Set nav links relative to base path (HA ingress compatibility)
+    document.getElementById('nav-dashboard').href = BASE_PATH;
+    document.getElementById('nav-nodes').href = BASE_PATH + 'nodes';
+    document.getElementById('nav-status').href = BASE_PATH + 'status';
+    document.getElementById('nav-yaml').href = BASE_PATH + 'yaml';
+    document.getElementById('nav-cca').href = BASE_PATH + 'cca';
     
     function formatBytes(bytes) {
       if (bytes < 1024) return bytes + ' B';
@@ -3473,7 +3523,7 @@ void TigoWebServer::get_esp_status_html(PSRAMString& html) {
           
           // Wait 3 seconds then restart
           setTimeout(() => {
-            window.location.href = '/';
+            window.location.href = BASE_PATH;
           }, 3000);
         } else {
           throw new Error('Failed to reset node table');
@@ -3563,11 +3613,11 @@ void TigoWebServer::get_yaml_config_html(PSRAMString& html) {
       </div>
     </div>
     <div class="nav">
-      <a href="/">Dashboard</a>
-      <a href="/nodes">Node Table</a>
-      <a href="/status">ESP32 Status</a>
-      <a href="/yaml" class="active">YAML Config</a>
-      <a href="/cca">CCA Info</a>
+      <a href="#" id="nav-dashboard">Dashboard</a>
+      <a href="#" id="nav-nodes">Node Table</a>
+      <a href="#" id="nav-status">ESP32 Status</a>
+      <a href="#" id="nav-yaml" class="active">YAML Config</a>
+      <a href="#" id="nav-cca">CCA Info</a>
     </div>
   </div>
   
@@ -3631,16 +3681,26 @@ void TigoWebServer::get_yaml_config_html(PSRAMString& html) {
   <script>
     // API Token configuration
     const API_TOKEN = ")html" + api_token_ + R"html(";
-    
+
+    // Detect ingress base path for HA ingress compatibility
+    function getBasePath() {
+      const path = window.location.pathname;
+      const lastSlash = path.lastIndexOf('/');
+      return path.substring(0, lastSlash + 1);
+    }
+    const BASE_PATH = getBasePath();
+
     // Fetch wrapper that includes authorization header if token is set
     async function apiFetch(url, options = {}) {
       if (API_TOKEN) {
         options.headers = options.headers || {};
         options.headers['Authorization'] = 'Bearer ' + API_TOKEN;
       }
-      return fetch(url, options);
+      // Prefix with BASE_PATH for HA ingress compatibility
+      const fullUrl = BASE_PATH + url.replace(/^\//, '');
+      return fetch(fullUrl, options);
     }
-    
+
     // Dark mode support
     let darkMode = localStorage.getItem('darkMode') === 'true';
     
@@ -3662,6 +3722,13 @@ void TigoWebServer::get_yaml_config_html(PSRAMString& html) {
     
     // Apply theme on page load
     applyTheme();
+
+    // Set nav links relative to base path (HA ingress compatibility)
+    document.getElementById('nav-dashboard').href = BASE_PATH;
+    document.getElementById('nav-nodes').href = BASE_PATH + 'nodes';
+    document.getElementById('nav-status').href = BASE_PATH + 'status';
+    document.getElementById('nav-yaml').href = BASE_PATH + 'yaml';
+    document.getElementById('nav-cca').href = BASE_PATH + 'cca';
     
     function getSelectedSensors() {
       const deviceSensors = ['power_in', 'power_out', 'peak_power', 'voltage_in', 'voltage_out', 'current_in', 'current_out',
@@ -3820,11 +3887,11 @@ void TigoWebServer::get_cca_info_html(PSRAMString& html) {
       </div>
     </div>
     <div class="nav">
-      <a href="/">Dashboard</a>
-      <a href="/nodes">Node Table</a>
-      <a href="/status">ESP32 Status</a>
-      <a href="/yaml">YAML Config</a>
-      <a href="/cca" class="active">CCA Info</a>
+      <a href="#" id="nav-dashboard">Dashboard</a>
+      <a href="#" id="nav-nodes">Node Table</a>
+      <a href="#" id="nav-status">ESP32 Status</a>
+      <a href="#" id="nav-yaml">YAML Config</a>
+      <a href="#" id="nav-cca" class="active">CCA Info</a>
     </div>
   </div>
   
@@ -3863,16 +3930,26 @@ void TigoWebServer::get_cca_info_html(PSRAMString& html) {
   <script>
     // API Token configuration
     const API_TOKEN = ")html" + api_token_ + R"html(";
-    
+
+    // Detect ingress base path for HA ingress compatibility
+    function getBasePath() {
+      const path = window.location.pathname;
+      const lastSlash = path.lastIndexOf('/');
+      return path.substring(0, lastSlash + 1);
+    }
+    const BASE_PATH = getBasePath();
+
     // Fetch wrapper that includes authorization header if token is set
     async function apiFetch(url, options = {}) {
       if (API_TOKEN) {
         options.headers = options.headers || {};
         options.headers['Authorization'] = 'Bearer ' + API_TOKEN;
       }
-      return fetch(url, options);
+      // Prefix with BASE_PATH for HA ingress compatibility
+      const fullUrl = BASE_PATH + url.replace(/^\//, '');
+      return fetch(fullUrl, options);
     }
-    
+
     // Dark mode support
     let darkMode = localStorage.getItem('darkMode') === 'true';
     
@@ -3894,6 +3971,13 @@ void TigoWebServer::get_cca_info_html(PSRAMString& html) {
     
     // Apply theme on page load
     applyTheme();
+
+    // Set nav links relative to base path (HA ingress compatibility)
+    document.getElementById('nav-dashboard').href = BASE_PATH;
+    document.getElementById('nav-nodes').href = BASE_PATH + 'nodes';
+    document.getElementById('nav-status').href = BASE_PATH + 'status';
+    document.getElementById('nav-yaml').href = BASE_PATH + 'yaml';
+    document.getElementById('nav-cca').href = BASE_PATH + 'cca';
     
     function formatTime(seconds) {
       if (!seconds || seconds === 0 || seconds > 4294967) return 'Never'; // > ~49 days indicates invalid/never

--- a/docs/WEB_SERVER_README.md
+++ b/docs/WEB_SERVER_README.md
@@ -148,6 +148,25 @@ curl http://esp32/api/health
 
 ---
 
+## Home Assistant Ingress
+
+The web UI supports proxying through Home Assistant's reverse proxy with a dynamic URL prefix, compatible with both [Home Assistant Ingress](https://developers.home-assistant.io/docs/add-ons/presentation/#ingress) and the community [hass_ingress](https://github.com/lovelylain/hass_ingress) integration.
+
+To enable ingress support, add the following to your `sdkconfig_options` so the ESP-IDF HTTP server can handle the longer URIs and headers that HA Ingress generates:
+
+```yaml
+esp32:
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_HTTPD_MAX_REQ_HDR_LEN: "2048"
+      CONFIG_HTTPD_MAX_URI_LEN: "1024"
+```
+
+The component automatically detects the ingress base path from the `X-Ingress-Path` header and rewrites all internal links accordingly — no additional configuration required.
+
+---
+
 ## Configuration
 
 ```yaml


### PR DESCRIPTION
This PR adds HA Ingress integration support (https://github.com/lovelylain/hass_ingress). Summary of proposed changes:

- Replace hardcoded nav hrefs (/, /nodes, /status, /yaml, /cca) with dynamic IDs set by JavaScript on all 5 pages
- Add getBasePath() helper that reads window.location.pathname to detect the HA Ingress-proxied URL prefix
- Update apiFetch() on all 5 pages to prepend BASE_PATH to all API calls so /api/* requests resolve correctly under the ingress proxy path
- Fix post-reset redirect on Status page to use BASE_PATH instead of '/'
- No C++ changes required; purely client-side JavaScript routing fix