### PR TITLE
fix(tsdb): serialize all LittleFS access behind one lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Opening the web UI could reboot the device.** History pages read the TSDB from the web server's task while the 30-minute snapshot writes it from another — and on the ESP32-S3 every flash access, read included, cuts the instruction cache on both cores, so the two collide and fault (`Fault - Unknown`). All LittleFS access now goes through one lock. History requests can queue briefly (a month-range query holds the flash ~2.3 s) and return an error rather than hang if they wait more than 15 s.
+
 ## [2.0.0-beta.5] - 2026-07-25
 
 ### Added

--- a/components/tigo_monitor/tigo_history.cpp
+++ b/components/tigo_monitor/tigo_history.cpp
@@ -18,6 +18,26 @@ namespace tigo_monitor {
 
 static const char *const TAG = "tigo_history";
 
+// How long a reader waits for the flash lock before giving up. Readers now
+// queue behind each other and behind the writer's commit, and a month-range
+// query holds the bus ~2.3 s, so several stacked requests can legitimately
+// wait a while. Generous enough that normal dashboard traffic never trips it;
+// bounded so a wedged holder degrades the API instead of hanging httpd.
+static constexpr uint32_t kFsLockReaderWaitMs = 15000;
+
+// A null handle means the lock does not exist yet (pre-init, single-threaded)
+// and is treated as acquired but never given back.
+TigoHistory::FlashLock::FlashLock(TigoHistory *hist, uint32_t timeout_ms)
+    : mutex_(hist != nullptr ? hist->fs_mutex_ : nullptr) {
+  const TickType_t wait =
+      (timeout_ms == 0) ? portMAX_DELAY : pdMS_TO_TICKS(timeout_ms);
+  held_ = (mutex_ == nullptr) || (xSemaphoreTakeRecursive(mutex_, wait) == pdTRUE);
+}
+
+TigoHistory::FlashLock::~FlashLock() {
+  if (mutex_ != nullptr && held_) xSemaphoreGiveRecursive(mutex_);
+}
+
 // Encoded row pushed onto the writer queue. Layout matches the schemas below:
 // — system_values mirror kSystemParamNames (14 entries)
 // — panel_values is laid out as [panel_db_0 first 16][panel_db_1 next 16]
@@ -84,6 +104,18 @@ static constexpr const char *kPanelMapPath = "/tsdb/panel_map.json";
 static constexpr const char *kJournalMarkerPath = "/tsdb/.jcommit";
 
 bool TigoHistory::init() {
+  // Created before any flash touch so every path below is already covered.
+  // Recursive because get_or_assign_slot() holds it across open_panel_db_()
+  // and save_slot_map_(), which each take it again.
+  if (fs_mutex_ == nullptr) {
+    fs_mutex_ = xSemaphoreCreateRecursiveMutex();
+    if (fs_mutex_ == nullptr) {
+      ESP_LOGE(TAG, "could not create flash mutex");
+      return false;
+    }
+  }
+  FlashLock lock(this, 0);
+
   if (!mount_filesystem_())
     return false;
   if (!init_system_db_())
@@ -331,6 +363,11 @@ uint8_t TigoHistory::get_or_assign_slot(const std::string &barcode_last6) {
   slot_map_[barcode_last6] = slot;
   slot_to_barcode_[slot] = barcode_last6;
 
+  // Runs on the ESPHome loop task. tsdb_open and the panel_map.json write below
+  // both hit flash, so they have to serialize against the writer's commit and
+  // any in-flight history query. Held across both (recursive mutex).
+  FlashLock lock(this, 0);
+
   // Lazy DB open: only commit panels<idx>.tsdb to flash when this slot's
   // bucket actually has its first panel. Pays the ~290ms tsdb_open cost on
   // the slot-assignment path (typically once per ~16 panels at install
@@ -459,6 +496,15 @@ int TigoHistory::iterate_power(uint32_t start_ts, uint32_t end_ts,
   if (end_ts < start_ts)
     return 0;
 
+  // Runs on the esp_http_server task (tskNO_AFFINITY — can be either core).
+  // Held across the whole query: init/next/close are all flash reads, and any
+  // one of them overlapping the writer's commit faults the writer.
+  FlashLock lock(this, kFsLockReaderWaitMs);
+  if (!lock.held()) {
+    ESP_LOGW(TAG, "iterate_power: timed out waiting for flash lock");
+    return -1;
+  }
+
   // Read only columns 0 (total_p) and 1 (total_e). Cuts flash IO roughly 7x
   // versus reading the full 14-param row.
   uint8_t cols[] = {0, 1};
@@ -492,6 +538,13 @@ int TigoHistory::iterate_panel(uint8_t slot, uint32_t start_ts, uint32_t end_ts,
   size_t db_idx = slot / kPanelsPerDb;
   uint8_t col = slot % kPanelsPerDb;
   if (panel_db_[db_idx] == nullptr) return -1;
+
+  // See iterate_power: same httpd-task flash reads, same lock.
+  FlashLock lock(this, kFsLockReaderWaitMs);
+  if (!lock.held()) {
+    ESP_LOGW(TAG, "iterate_panel: timed out waiting for flash lock");
+    return -1;
+  }
 
   tsdb_query_t q;
   uint8_t cols[] = {col};
@@ -544,6 +597,19 @@ void TigoHistory::writer_task_loop_() {
                (unsigned long) row.timestamp);
       continue;
     }
+
+    // Everything from here to the end of the iteration touches flash: the
+    // system write, each panel write, and the journal commit. Take the lock
+    // once for the whole batch rather than per call — a reader slipping in
+    // between two writes is just as fatal as one landing mid-write.
+    //
+    // Deliberately scoped BELOW xQueueReceive: holding this across the
+    // portMAX_DELAY receive would block every reader for the full 30-minute
+    // gap between snapshots. It releases when the iteration ends.
+    //
+    // portMAX_DELAY, not a timeout: dropping a snapshot loses data, and the
+    // only holders are bounded (a query, a slot save).
+    FlashLock lock(this, 0);
 
     uint32_t t0 = (uint32_t) (esp_timer_get_time() / 1000);
 

--- a/components/tigo_monitor/tigo_history.h
+++ b/components/tigo_monitor/tigo_history.h
@@ -15,6 +15,7 @@
 #include "esp_littlefs.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
+#include "freertos/semphr.h"
 #include "freertos/task.h"
 
 #include <atomic>
@@ -65,6 +66,27 @@ struct PanelSlot {
 
 class TigoHistory {
  public:
+  // RAII guard over the component-wide flash lock (see fs_mutex_ below).
+  // ANY code that touches littlefs must hold this for the whole operation —
+  // including callers outside this class that reach flash directly, such as
+  // /api/tsdb/stats (esp_littlefs_info -> lfs_fs_size traverses block
+  // metadata, which is a flash read like any other).
+  //
+  // timeout_ms == 0 means wait forever. Always check held() before proceeding
+  // when you passed a timeout; a false return means "do not touch flash".
+  class FlashLock {
+   public:
+    explicit FlashLock(TigoHistory *hist, uint32_t timeout_ms = 15000);
+    ~FlashLock();
+    FlashLock(const FlashLock &) = delete;
+    FlashLock &operator=(const FlashLock &) = delete;
+    bool held() const { return held_; }
+
+   private:
+    SemaphoreHandle_t mutex_;
+    bool held_;
+  };
+
   // Mounts LittleFS on the `tsdb` partition and opens system + panel DBs.
   // Loads /tsdb/panel_map.json if present. Returns true on success.
   bool init();
@@ -158,6 +180,30 @@ class TigoHistory {
   // Next free slot to assign. Slots are never recycled — replacements keep
   // their position in history forever.
   uint8_t next_free_slot_{0};
+
+  // Serializes EVERY littlefs/SPI-flash access this component makes, across all
+  // three tasks that reach flash: the writer task (tsdb_write_h + journal
+  // commit), the ESPHome loop task (slot assignment -> tsdb_open +
+  // panel_map.json), and the esp_http_server task (history queries).
+  //
+  // Why a component-level lock and not esp_tsdb's own: esp_tsdb's mutex is
+  // per-handle (tsdb_internal.h:137), so a read of panels<N> and a write of
+  // system are never serialized against each other — they are different
+  // handles on the same flash chip. And the httpd task runs at
+  // tskNO_AFFINITY, so it floats to core 0 and escapes the writer's core-1
+  // pin entirely.
+  //
+  // What goes wrong without it (reproduced on the rig 2026-07-27, first try):
+  // with CONFIG_SPI_FLASH_AUTO_SUSPEND off, every SPI1 op — read as well as
+  // write — calls spi_flash_disable_interrupts_caches_and_other_cpu, which
+  // cuts I-cache on BOTH cores and parks the other one. Two tasks entering
+  // that path concurrently fault inside the stall coordination itself:
+  //   spi_flash_disable_interrupts_caches_and_other_cpu (cache_utils.c:176)
+  //     <- cache_disable <- spi1_start <- esp_flash_read <- lfs_bd_read
+  //     <- lfs_file_flush <- vfs fsync <- tsdb_write_block  == "Fault - Unknown"
+  // A month-range history query holds the bus for ~2.3 s, so an open web UI
+  // reliably overlaps the 30-minute snapshot commit.
+  SemaphoreHandle_t fs_mutex_{nullptr};
 
   QueueHandle_t queue_{nullptr};
   TaskHandle_t task_{nullptr};

--- a/components/tigo_server/tigo_web_server.cpp
+++ b/components/tigo_server/tigo_web_server.cpp
@@ -3667,6 +3667,19 @@ esp_err_t TigoWebServer::api_tsdb_stats_handler(httpd_req_t *req) {
     return ESP_OK;
   }
 
+  // This handler reaches flash directly rather than through TigoHistory's
+  // iterate_* helpers, so it has to take the flash lock itself: esp_littlefs_info
+  // calls lfs_fs_size, which traverses block metadata (a flash read), and
+  // tsdb_get_stats_h can fall through to the file. Running either concurrently
+  // with the writer's commit faults the writer in the SPI1 cache-disable path.
+  tigo_monitor::TigoHistory::FlashLock lock(hist);
+  if (!lock.held()) {
+    httpd_resp_set_status(req, "503 Service Unavailable");
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, "{\"error\":\"flash busy\"}");
+    return ESP_OK;
+  }
+
   PSRAMString json;
   char buf[160];
 


### PR DESCRIPTION
Opening the web UI could reboot the rig. Reproduced on demand and fixed.

The crash class has been chased since 07-21 and every previous round only moved the victim: WiFi ISR -> UART ringbuf -> the writer's own flush. The mitigation stack (writer pinned to core 1, BLE scan-off, 5->30 min snapshots, 274c8fc) took MTTF from ~2.5 min to 42 h but never closed it.

Root cause. With CONFIG_SPI_FLASH_AUTO_SUSPEND off, every SPI1 operation -- a read exactly as much as a write -- calls
spi_flash_disable_interrupts_caches_and_other_cpu: I-cache off on BOTH cores, non-IRAM ISRs masked, the other core parked. Three tasks reach flash here and only two were covered by the core-1 pin:

  - writer task        tsdb_write_h x4 + commit_journal_
  - ESPHome loop task  slot assignment -> tsdb_open + panel_map.json
  - esp_http_server    history queries -- tskNO_AFFINITY, so it floats to
                       core 0 and escapes the pin entirely

Nothing serialized them. esp_tsdb's mutex is per-handle (tsdb_internal.h:137), so a read of panels<N> and a write of system are different handles on the same chip and never contend. iterate_* already conceded the hazard for OTA ("no littlefs reads during OTA") but not for the writer's own commit.

Evidence. Controlled A/B on the rig, same build and ELF:

  control  10:13:13 commit, /api/status only     -> survived, writes 7783->7784
  test     10:43:13 commit, 4x range=month loops -> crashed, first attempt

The test backtrace is the mechanism rather than a symptom -- the writer faults inside the stall coordination itself, while taking the bus a reader already holds:

  spi_flash_disable_interrupts_caches_and_other_cpu  cache_utils.c:176
    <- cache_disable <- spi1_start <- esp_flash_read <- lfs_bd_read
    <- lfs_file_flush <- vfs fsync <- tsdb_write_block

Read duration is the lever: range=month costs 2345 ms of flash reads vs 113-162 ms for week, so an open UI reliably overlaps the commit. That is why three crashes (07-26 10:13, 07-26 16:43, 07-27 08:43) all landed on their run's snapshot phase.

Fix. One recursive mutex over every LittleFS access, with a public FlashLock RAII guard. The writer holds it across the whole batch -- scoped below xQueueReceive, since holding it across that blocking receive would lock readers out for the full 30-minute gap. Readers take it for query_init->close with a 15 s bound so a wedged holder degrades the API instead of hanging httpd. get_or_assign_slot holds it across both its flash touches, hence recursive.

Auditing for paths the two proven ones would miss turned up /api/tsdb/stats, which reaches flash outside TigoHistory via esp_littlefs_info -> lfs_fs_size (a block-metadata traversal). It takes the lock too.

Verified. Identical kill load across the 14:06:57 commit: survived, uptime monotonic 1660->1928, system writes 7798->7799 with all four DBs stamped 14:07:00 -- a real commit under load, not a false pass. Long-soak evidence (beating the 42 h best) is still outstanding.

Cost: concurrent history requests now queue behind each other and behind the commit. Under 4-way month-query saturation a few /api/status polls timed out -- httpd worker contention, not the lock.

Claude-Session: https://claude.ai/code/session_01RgSnMCa3JQigphGnPbazdw