### PR TITLE
fix(server): correct the PSRAM boot warning

### DIFF
--- a/components/tigo_server/tigo_web_server.cpp
+++ b/components/tigo_server/tigo_web_server.cpp
@@ -148,7 +148,7 @@ void TigoWebServer::setup() {
     ESP_LOGW(TAG, "*     speed: 200MHz                                          *");
 #endif
     ESP_LOGW(TAG, "*                                                            *");
-    ESP_LOGW(TAG, "* PSRAM is REQUIRED for 15+ devices!                        *");
+    ESP_LOGW(TAG, "* PSRAM is REQUIRED - expect instability without it!        *");
     ESP_LOGW(TAG, "* See boards/ folder for complete examples.                 *");
     ESP_LOGW(TAG, "**************************************************************");
     ESP_LOGW(TAG, "%s", "");


### PR DESCRIPTION
The boot-time warning in `tigo_web_server.cpp:151` said:

```
* PSRAM is REQUIRED for 15+ devices!                        *
```

PSRAM is required outright — that's what the docs say as of #38. This was the last place in the tracked source still quoting the old threshold (`CLAUDE.md` and `.github/copilot-instructions.md` also do, but those are agent instructions rather than user-facing).

New text, padded to the box's existing 61-char body width:

```
* PSRAM is REQUIRED - expect instability without it!        *
```

Verified with `esphome compile boards/test-local-tigomonitor.yaml` — builds clean, 77.4% flash.

Does not close #39, which is about enforcing the requirement in codegen rather than warning about it at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgSnMCa3JQigphGnPbazdw