### PR TITLE
fix(p4): put the P4 on the sidecar pin too — it was stuck at esp_tsdb 2.0.3

### DIFF
--- a/boards/esp32p4-evboard.yaml
+++ b/boards/esp32p4-evboard.yaml
@@ -43,12 +43,19 @@ esp32:
       # `esp_task_stack_is_sane_cache_disabled` (discussion #31).
       execute_from_psram: true
     components:
-      # esp_tsdb backs the History view; littlefs is its filesystem. The P4
-      # target still needs the RAR/esp_tsdb fork (upstream 2.1.0's manifest
-      # doesn't list esp32p4 yet); S3/other targets use `zakery292/esp_tsdb^2.1.0`.
+      # esp_tsdb backs the History view; littlefs is its filesystem.
+      #
+      # Same fork ref as the AtomS3R, for two reasons at once. The P4 has always
+      # needed the fork because upstream's manifest still doesn't list esp32p4;
+      # every board now also needs it for the sidecar header, without which a
+      # history commit costs 21.4 s instead of 633 ms (see the AtomS3R config).
+      #
+      # This ref replaces `tigomonitor`, which was pinned here before and sat at
+      # 2.0.3 — so the P4 was missing everything since, sidecar included. Pinned
+      # by SHA rather than branch so it cannot move under a build.
       - name: zakery292/esp_tsdb
         source: https://github.com/RAR/esp_tsdb.git
-        ref: tigomonitor
+        ref: ebfc360f00263ab90116ee3e556a9153ab4041a2
       - joltwallet/littlefs^1.16
     sdkconfig_options:
       # CPU frequency (P4 runs at 400MHz)

--- a/boards/esp32s3-atoms3r.yaml
+++ b/boards/esp32s3-atoms3r.yaml
@@ -50,7 +50,7 @@ esp32:
       # and this is the reference config people copy.
       - name: zakery292/esp_tsdb
         source: https://github.com/RAR/esp_tsdb.git
-        ref: 3fb785ffe0e280e7645a598f1cf82f6babe72143
+        ref: ebfc360f00263ab90116ee3e556a9153ab4041a2
       # LittleFS — backing filesystem for the tsdb partition
       - joltwallet/littlefs^1.16
     sdkconfig_options:

--- a/boards/test-p4-ble-tigomonitor.yaml
+++ b/boards/test-p4-ble-tigomonitor.yaml
@@ -25,12 +25,13 @@ esp32:
       # esp_task_stack_is_sane_cache_disabled (discussion #31).
       execute_from_psram: true
     components:
-      # Upstream 2.1.0 has everything we need code-wise, but its manifest still
-      # lacks the esp32p4 target, so P4 stays on the RAR/esp_tsdb fork's
-      # `tigomonitor` branch (= 2.1.0 + esp32p4 manifest entry) until that lands.
+      # Same fork ref as the board configs: needed on P4 because upstream's
+      # manifest still lacks the esp32p4 target, and needed everywhere for the
+      # sidecar header (21.4 s -> 633 ms per history commit). Replaces the
+      # `tigomonitor` branch, which sat at 2.0.3 and had neither.
       - name: zakery292/esp_tsdb
         source: https://github.com/RAR/esp_tsdb.git
-        ref: tigomonitor
+        ref: ebfc360f00263ab90116ee3e556a9153ab4041a2
       # LittleFS — backing filesystem for the tsdb partition
       - joltwallet/littlefs^1.16
     sdkconfig_options:

--- a/boards/test-p4-tigomonitor.yaml
+++ b/boards/test-p4-tigomonitor.yaml
@@ -25,12 +25,13 @@ esp32:
       # esp_task_stack_is_sane_cache_disabled (discussion #31).
       execute_from_psram: true
     components:
-      # Upstream 2.1.0 has everything we need code-wise, but its manifest still
-      # lacks the esp32p4 target, so P4 stays on the RAR/esp_tsdb fork's
-      # `tigomonitor` branch (= 2.1.0 + esp32p4 manifest entry) until that lands.
+      # Same fork ref as the board configs: needed on P4 because upstream's
+      # manifest still lacks the esp32p4 target, and needed everywhere for the
+      # sidecar header (21.4 s -> 633 ms per history commit). Replaces the
+      # `tigomonitor` branch, which sat at 2.0.3 and had neither.
       - name: zakery292/esp_tsdb
         source: https://github.com/RAR/esp_tsdb.git
-        ref: tigomonitor
+        ref: ebfc360f00263ab90116ee3e556a9153ab4041a2
       # LittleFS — backing filesystem for the tsdb partition
       - joltwallet/littlefs^1.16
     sdkconfig_options:

--- a/site/boards.js
+++ b/site/boards.js
@@ -18,7 +18,7 @@ export const BOARDS = [
     frameworkComponents: ['joltwallet/littlefs^1.16'],
     hostedComponent: {
       source: 'https://github.com/RAR/esp_tsdb.git',
-      ref: '3fb785ffe0e280e7645a598f1cf82f6babe72143',
+      ref: 'ebfc360f00263ab90116ee3e556a9153ab4041a2',
     },
     sdkconfig: {
       CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240: 'y',
@@ -239,7 +239,9 @@ font:
     // boards crash-loop at boot with esp_task_stack_is_sane_cache_disabled (#31).
     frameworkAdvanced: { enable_idf_experimental_features: true, execute_from_psram: true },
     frameworkComponents: ['joltwallet/littlefs^1.16'],
-    hostedComponent: { source: 'https://github.com/RAR/esp_tsdb.git', ref: 'tigomonitor' },
+    // Same ref as the AtomS3R: the P4 needs the fork for its manifest target,
+    // and every board needs it for the sidecar header. Was `tigomonitor` (2.0.3).
+    hostedComponent: { source: 'https://github.com/RAR/esp_tsdb.git', ref: 'ebfc360f00263ab90116ee3e556a9153ab4041a2' },
     sdkconfig: {
       CONFIG_ESP32P4_DEFAULT_CPU_FREQ_400: 'y',
       CONFIG_UART_ISR_IN_IRAM: 'y',


### PR DESCRIPTION
Follow-up to #45, which moved only the AtomS3R onto the sidecar header. The P4 kept its older `ref: tigomonitor` pin and so silently stayed on **21.4 s history commits** — and since that branch sits at 2.0.3, it was also missing everything released after it.

Surfaced by @davidcoulson asking, on #45, whether he should add the new pin to his board YAML. On a P4 the answer was no, and it would have failed confusingly.

## Why the two boards couldn't just share a ref

| branch | version | sidecar | `esp32p4` in manifest |
|---|---|---|---|
| `tigomonitor` (P4 pinned this) | 2.0.3 | no | **yes** |
| `3fb785f` (#45's pin) | 2.3.0 | **yes** | no |

The sidecar branch is based on upstream 2.3.0, whose manifest doesn't list `esp32p4`. The component manager enforces `targets:`, so pinning it on a P4 fails at **dependency resolution — before anything compiles**.

## Fix

Added the one missing manifest line to the fork: **`RAR/esp_tsdb@ebfc360`** = `3fb785f` + `- esp32p4`. That makes a single ref valid for every board. The full esp_tsdb host suite still passes on it (sidecar, multi, resize, schema, freecap, wrap).

All six configs that pin `esp_tsdb` now point at `ebfc360`:

- `boards/esp32s3-atoms3r.yaml`, `boards/esp32p4-evboard.yaml`
- `boards/test-p4-tigomonitor.yaml`, `boards/test-p4-ble-tigomonitor.yaml`
- the Config Builder's two board entries

`test-idf6-tigomonitor.yaml` and `example-p4.yaml` inherit it via `!include`. No `ref: tigomonitor` remains anywhere in tracked source.

## Verification

- **P4 compiles against the new ref**, and the fetched dependency is confirmed to be the fork — 60 sidecar references in `tsdb_core.c`, `esp32p4` in its manifest. Not a cached resolve: flash moved 1,432,902 → 1,437,230 bytes
- 46/46 site tests
- The rig's deploy config is on the same ref, so reference config and live device stay identical

## Note for the release

`v2.0.0-rc.1` shipped with the P4 on the old pin. This is exactly what an RC is for; worth folding into rc.2 or the final tag.