### PR TITLE
docs(troubleshooting): T-CAN485 needs GPIO16 driven, not just 17/19

### DIFF
--- a/site/src/content/docs/guides/troubleshooting.md
+++ b/site/src/content/docs/guides/troubleshooting.md
@@ -34,6 +34,7 @@ Still stuck? The rest of this page is organised by symptom.
 | Symptom | Solution |
 |---------|----------|
 | No devices discovered | Check UART wiring, verify 38400 baud ([Wiring](/esphome-tigomonitor/guides/wiring/)) |
+| No devices discovered on a LilyGO T-CAN485 | Drive GPIO16, 17 and 19 high — the transceiver is unpowered without them (below) |
 | High packet loss | Add `CONFIG_UART_ISR_IN_IRAM: "y"` ([UART Optimization](/esphome-tigomonitor/guides/uart-optimization/)) |
 | Memory exhaustion | Use an ESP32-S3 with PSRAM — it's required |
 | CCA sync fails (local HTTP) | Verify CCA IP, check network connectivity |
@@ -56,6 +57,48 @@ Still stuck? The rest of this page is organised by symptom.
 2. Confirm baud rate is 38400
 3. Check Tigo system is powered and communicating
 4. Look for any "Frame" messages in ESPHome logs
+
+### No Devices Found on a LilyGO T-CAN485
+
+**Symptoms:** Nothing received at all — the log shows no frames, and a UART debug
+block shows only `>>>` (transmit) lines with no `<<<` (receive) lines. An ESP32
+loopback or TX test still passes, because it never leaves the chip.
+
+**Cause:** the board's RS485 front end needs **three** GPIOs held high, and the
+one people miss is GPIO16. It is not an enable — it is `5V_EN`, the ME2107 boost
+that supplies the MAX13487E transceiver. Left floating, the transceiver has no
+power and the receiver is deaf no matter how correct the wiring and baud rate are.
+
+**Solution:** drive all three, and leave them on:
+
+```yaml
+switch:
+  - platform: gpio
+    id: rs485_power_5v
+    pin: GPIO16          # 5V boost that feeds the transceiver
+    internal: true
+    restore_mode: ALWAYS_ON
+  - platform: gpio
+    id: rs485_auto_direction
+    pin: GPIO17          # /RE high => AutoDirection controls the receiver
+    internal: true
+    restore_mode: ALWAYS_ON
+  - platform: gpio
+    id: rs485_chip_enable
+    pin: GPIO19          # SHDN high => normal operation (low = whole chip off)
+    internal: true
+    restore_mode: ALWAYS_ON
+```
+
+Simpler still, include the shipping board file as a package and let it supply the
+front end for you — `boards/esp32-lilygo-t-can485.yaml`, as
+`boards/example-t-can485.yaml` does. The [config builder](/esphome-tigomonitor/config-builder/)
+also emits all three when you pick this board.
+
+**While you are in there:** do not add a test writer that transmits bytes on this
+UART. `tigo_monitor` is receive-only, and the MAX13487E has no driver-enable pin —
+AutoDirection turns the driver on by itself whenever it sees activity, so those
+test bytes go straight onto your live CCA↔TAP bus.
 
 ### Devices Found But No Barcodes
 


### PR DESCRIPTION
Closes #48.

A hand-written LilyGO T-CAN485 config that enables `/RE` (GPIO17) and `SHDN` (GPIO19) but leaves **GPIO16** floating receives nothing at all. GPIO16 isn't an enable — it's `5V_EN`, the ME2107 boost that supplies the MAX13487E. Unpowered transceiver, deaf receiver, and an ESP32-side loopback test still passes, so the symptom sends people looking at baud rates and CCA firmware versions instead.

The shipping board file (`boards/esp32-lilygo-t-can485.yaml`) has always set all three, and so does the config builder (`site/boards.js`), so only people rolling their own YAML hit this. Nothing under `site/` named GPIO16 before this.

Adds to `guides/troubleshooting.md`:
- quick-reference row
- a **No Devices Found on a LilyGO T-CAN485** section — the `>>>`-with-no-`<<<` symptom, why 16 is the one that gets missed, the three-switch block, a pointer to including the board file as a package, and a warning not to add a UART test writer (the MAX13487E has no driver-enable pin, so test bytes land on the live CCA↔TAP bus)

Docs-only. Site builds clean, internal link validation passes. Fix confirmed working by the reporter in #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)