### PR TITLE
fix(sensor): reject a per-panel entry that selects no measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A per-panel sensor entry that lists no measurements is now a config error instead of a silent no-op.** `address` and `name` say which panel and what to call it; the entities come from the sub-keys (`power: {}`, `voltage_in: {}`, ...). An entry with none produced nothing at all, with no warning — which reads as "my panels never appeared in Home Assistant" and sends people looking at heap limits and device counts ([#48](https://github.com/RAR/esphome-tigomonitor/issues/48)). Validation now names the offending entry and lists the available sub-keys.
+
 ## [2.0.0] - 2026-08-14
 
 Same firmware as [2.0.0-rc.2] — no code changed. What changed is the answer to

--- a/components/tigo_monitor/sensor.py
+++ b/components/tigo_monitor/sensor.py
@@ -148,6 +148,40 @@ def _auto_template_sensor_config(config):
 
     return config
 
+# Every measurement a per-device entry can ask for. An entry that names none of
+# these creates no entities at all, so validation rejects it (see
+# _require_device_sub_sensor below).
+_DEVICE_SUB_SENSOR_KEYS = (
+    CONF_POWER_IN, CONF_POWER, CONF_PEAK_POWER, CONF_POWER_OUT,
+    CONF_VOLTAGE_IN, CONF_VOLTAGE_OUT, CONF_CURRENT_IN, CONF_CURRENT_OUT,
+    CONF_DUTY_CYCLE, CONF_TEMPERATURE, CONF_RSSI,
+    CONF_BARCODE, CONF_FIRMWARE_VERSION, CONF_DEVICE_INFO,
+    CONF_EFFICIENCY, CONF_POWER_FACTOR, CONF_LOAD_FACTOR,
+)
+
+
+def _require_device_sub_sensor(config):
+    """Reject a per-device entry that selects no measurements.
+
+    `address` + `name` only say *which* panel and what to call it — the
+    entities come from the sub-keys. Without one, to_code() has nothing to
+    create and the entry is a silent no-op, which reads as "my panels never
+    showed up in Home Assistant" (issue #48).
+    """
+    if not any(key in config for key in _DEVICE_SUB_SENSOR_KEYS):
+        raise cv.Invalid(
+            f"Device sensor '{config[CONF_NAME]}' (address "
+            f"'{config[CONF_ADDRESS]}') selects no measurements, so it would "
+            "create no entities. Add at least one sub-key, e.g.:\n"
+            "    power: {}\n"
+            "    voltage_in: {}\n"
+            "    current_in: {}\n"
+            "    temperature: {}\n"
+            "Available: " + ", ".join(_DEVICE_SUB_SENSOR_KEYS)
+        )
+    return config
+
+
 # Schema for individual device sensors
 DEVICE_CONFIG_SCHEMA = cv.All(
     cv.Schema({
@@ -241,6 +275,7 @@ DEVICE_CONFIG_SCHEMA = cv.All(
             state_class=STATE_CLASS_MEASUREMENT,
         ),
     }).extend(cv.COMPONENT_SCHEMA),
+    _require_device_sub_sensor,
     _auto_template_sensor_config,
 )
 

--- a/site/src/content/docs/guides/configuration.md
+++ b/site/src/content/docs/guides/configuration.md
@@ -334,6 +334,10 @@ sensor:
     load_factor: {}
 ```
 
+`address` and `name` only say *which* panel and what to call it — the entities
+come from the sub-keys, so list at least one. An entry with none creates no
+entities, and is rejected at validation time rather than silently skipped.
+
 ### Grouping panels into HA sub-devices
 
 ESPHome's [sub-devices feature](https://esphome.io/components/esphome/#esphome-devices)


### PR DESCRIPTION
Follow-up to #48.

A per-panel sensor entry that carries only `address` and `name` creates no
entities. `address`/`name` say *which* panel and what to call it — the entities
come from the sub-keys (`power: {}`, `voltage_in: {}`, ...), so `to_code()`'s
loop had nothing to create and skipped the entry silently.

The reporter had 25 such entries, got four entities total, and reasonably read
that as a heap limit on a no-PSRAM ESP32 — so the failure mode costs people a
memory-bug hunt for a one-line config omission.

## Changes

- `components/tigo_monitor/sensor.py`: `_require_device_sub_sensor` chained into
  `DEVICE_CONFIG_SCHEMA`. The error names the entry and its address, shows a
  four-key example, and lists every available sub-key.
- `site/src/content/docs/guides/configuration.md`: a note under *Individual
  Device Sensors* saying the sub-keys are what produce the entities.
- `CHANGELOG.md` under `[Unreleased]`.

## Verification

- A config with a bare `address`/`name` entry now fails validation with the new
  message; the same config with `power: {}` added validates clean.
- `boards/example-t-can485.yaml` and `boards/test-p4-ble-tigomonitor.yaml` still
  validate clean — every shipped board file and the config builder already emit
  sub-keys, so nothing in-tree changes.
- Docs site builds clean (11 pages, internal link validation passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
