### PR TITLE
feat(boards): add the LilyGO T-Connect Pro Lite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **LilyGO T-Connect Pro Lite is a supported board.** ESP32-S3 with 8MB PSRAM, 8MB flash and wired Ethernet (W5500) — the full profile, web UI and on-flash history included, on a wired network. `boards/esp32s3-lilygo-t-connect-pro-lite.yaml` plus a ready-to-flash `boards/example-t-connect-pro-lite.yaml`. Contributed by @davidcoulson from a working install ([discussion #30](https://github.com/RAR/esphome-tigomonitor/discussions/30)); the pin map is theirs, and the config compiles clean here.
+- **The config builder can generate wired configs.** A board that declares an on-board Ethernet PHY now emits an `ethernet:` block and no `wifi:`/`captive_portal:` at all, and the Wi-Fi fields disappear from the form. Bluetooth is compiled out on this board to buy back flash, so CCA-over-BLE is unavailable there; HTTP CCA import is unaffected.
+
 ### Fixed
 - **A per-panel sensor entry that lists no measurements is now a config error instead of a silent no-op.** `address` and `name` say which panel and what to call it; the entities come from the sub-keys (`power: {}`, `voltage_in: {}`, ...). An entry with none produced nothing at all, with no warning — which reads as "my panels never appeared in Home Assistant" and sends people looking at heap limits and device counts ([#48](https://github.com/RAR/esphome-tigomonitor/issues/48)). Validation now names the offending entry and lists the available sub-keys.
 

--- a/boards/README.md
+++ b/boards/README.md
@@ -20,6 +20,27 @@ Assistant over the native API; it just cannot serve the dashboard.
 - **UART Buffers**: 2048 RX / 512 TX (increase RX to 8192 if using display package)
 - **Note**: When using `atoms3r-display.yaml` package, display updates compete with UART. See UART_OPTIMIZATION.md for packet loss mitigation. TX buffer can stay small since we only listen to the bus.
 
+#### `esp32s3-lilygo-t-connect-pro-lite.yaml` - LilyGO T-Connect Pro Lite (8MB PSRAM, wired)
+- **Board**: LilyGO T-Connect Pro Lite (ESP32-S3), 8MB flash, 8MB octal PSRAM
+- **Network**: wired Ethernet via an on-board W5500 — **no `wifi:` block**. Do not
+  add one; the radio would compete for the same lwIP socket budget for nothing
+- **CPU**: 240MHz
+- **RS485**: built-in transceiver on GPIO17 (TX) / GPIO18 (RX), on its own
+  hardware UART, so the USB serial console stays available
+- **Recommended for**: installations that want the full web UI on a wired
+  network. PSRAM and 8MB of flash mean `tigo_server` and on-flash history both fit
+- **Bluetooth**: compiled out to buy back flash, so the CCA-over-BLE bridge is
+  not available. HTTP CCA import works normally. Re-enabling BLE means dropping
+  the four `CONFIG_BT_*` lines *and* switching to `partitions/tigo-8mb-ble.csv`
+- **Ready-to-flash example**: `example-t-connect-pro-lite.yaml`
+- **Provenance**: contributed by @davidcoulson from a working install
+  ([discussion #30](https://github.com/RAR/esphome-tigomonitor/discussions/30)).
+  The pin map is the contributor's — no maintainer unit exists to check it
+  against, though the config compiles clean here. The screen-equipped "Pro" is a
+  different board and is not configured by this file
+- **Other on-board hardware** (pins documented in the board file, nothing
+  instantiated): RS232, CAN, four WS2812 LEDs, two buttons, a relay
+
 ### ESP32-P4 Boards
 
 #### `esp32p4-evboard.yaml` - ESP32-P4 Evaluation Board (32MB PSRAM)

--- a/boards/esp32s3-lilygo-t-connect-pro-lite.yaml
+++ b/boards/esp32s3-lilygo-t-connect-pro-lite.yaml
@@ -1,0 +1,157 @@
+# LilyGO T-Connect Pro Lite Configuration
+# ESP32-S3, 8MB flash, 8MB octal PSRAM, wired Ethernet (W5500), built-in RS485
+# Recommended for: installations that want the web UI on a wired network
+#
+# Contributed by @davidcoulson in discussion #30, from a working install. The
+# maintainer has no unit of this board, so the pin map below is the
+# contributor's, not something verified here — if yours behaves differently,
+# please say so on that discussion.
+#
+# WHAT THIS BOARD BRINGS
+# ----------------------
+# It is the full-fat profile: PSRAM for `tigo_server`, 8MB of flash for the
+# on-device history database, and Ethernet instead of WiFi. The Lite has no
+# screen; the "Pro" (with screen) is a different board and this file does not
+# configure its display.
+#
+# ETHERNET, NOT WIFI
+# ------------------
+# The `ethernet:` block below is board wiring — the W5500 is soldered on. Do NOT
+# also declare `wifi:` in a config that includes this file. ESPHome will let you
+# build both, and the S3's radio then competes for the same lwIP socket budget
+# for no benefit. Leave WiFi out; if you want it instead of Ethernet, remove the
+# `ethernet:` block rather than running the two side by side.
+#
+# OTHER ON-BOARD HARDWARE (not configured here, pins for reference)
+# -----------------------------------------------------------------
+# The board carries more than the Tigo build needs. None of it is instantiated —
+# every unused pin stays free — but the map is here so you can add what you want:
+#
+#   RS232 UART      TX GPIO4,  RX GPIO5
+#   CAN (TWAI)      TX GPIO6,  RX GPIO7
+#   WS2812 LEDs     GPIO46, GPIO3, GPIO21, GPIO41   (one LED each)
+#   Buttons         A GPIO39, B GPIO40
+#   Relay           GPIO8
+#
+# Discussion #30 has a worked example that drives the four LEDs from monitor
+# state (online status, night mode, percentage of optimizers reporting, output
+# versus peak) if you want that.
+
+esphome:
+  name: tigo-server
+  friendly_name: "Tigo Server"
+  # allow_partition_access in the OTA config requires ESPHome 2026.5.0+
+  min_version: "2026.5.0"
+
+esp32:
+  variant: esp32s3
+  board: esp32-s3-devkitc-1
+  flash_size: 8MB
+  partitions: partitions/tigo-8mb.csv
+  framework:
+    type: esp-idf
+    version: recommended
+    advanced:
+      # XIP-from-PSRAM — the fix for the tsdb flash-write crash
+      # (docs/tsdb-flash-crash-issue.md). Every history commit takes ESP-IDF's
+      # cross-core cache-disable; with code running from flash that stall raced
+      # network ISRs and faulted. This flag sets SPIRAM_FETCH_INSTRUCTIONS +
+      # SPIRAM_RODATA, which compiles the cache-disable out entirely. Costs
+      # ~1.7 MiB of PSRAM.
+      execute_from_psram: true
+    components:
+      # Time-series database for persistent history. Pinned to a fork by
+      # immutable SHA — see the long explanation in esp32s3-atoms3r.yaml and
+      # docs/esp-tsdb-fork.md. A branch can move under a build; a commit cannot.
+      - name: zakery292/esp_tsdb
+        source: https://github.com/RAR/esp_tsdb.git
+        ref: ebfc360f00263ab90116ee3e556a9153ab4041a2
+      # LittleFS — backing filesystem for the tsdb partition
+      - joltwallet/littlefs^1.16
+    sdkconfig_options:
+      CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240: "y"
+      # Run the UART ISR from IRAM. The single most important setting for frame
+      # loss — without it the ISR stalls whenever flash is busy and Tigo frames
+      # get dropped mid-burst.
+      CONFIG_UART_ISR_IN_IRAM: "y"
+      CONFIG_UART_RX_BUFFER_SIZE: "4096"
+      # TX stays small: tigo_monitor only ever listens to the bus.
+      CONFIG_UART_TX_BUFFER_SIZE: "256"
+      CONFIG_FREERTOS_QUEUE_REGISTRY_SIZE: "32"
+      CONFIG_LOG_DEFAULT_LEVEL_INFO: "y"
+      # PSRAM: 8MB octal at 80MHz
+      CONFIG_SPIRAM_MODE_OCT: "y"
+      CONFIG_SPIRAM_SPEED_80M: "y"
+      # Left OFF, unlike the WiFi boards. That option relocates the WiFi/lwIP
+      # buffer pool to PSRAM to save internal RAM, which matters when the radio
+      # is up. Here the radio is off and the W5500 driver keeps its buffers
+      # internal regardless, so it buys nothing.
+      CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP: "n"
+      # VFS directory operations (stat/unlink/rename/opendir), off by default in
+      # IDF. esp_tsdb reads database sizes via stat(), so without this the
+      # History page's size column reads 0 and esp_tsdb's unlink() recovery
+      # paths silently no-op.
+      CONFIG_VFS_SUPPORT_DIR: "y"
+      # More lwIP sockets for the web server + API running together (avoids
+      # "Failed to create socket" under load, #20).
+      CONFIG_LWIP_MAX_SOCKETS: "16"
+      CONFIG_LWIP_MAX_ACTIVE_TCP: "16"
+      CONFIG_LWIP_MAX_LISTENING_TCP: "16"
+      # Bluetooth off: it is dead weight on a wired board and buys back a large
+      # slice of flash. Adding the BLE CCA bridge means removing these four
+      # lines AND switching to partitions/tigo-8mb-ble.csv — the BLE stack does
+      # not fit the standard app slot.
+      CONFIG_BT_ENABLED: "n"
+      CONFIG_BLUEDROID_ENABLED: "n"
+      CONFIG_BT_BLE_42_FEATURES_SUPPORTED: "n"
+      CONFIG_BT_BLE_50_FEATURES_SUPPORTED: "n"
+
+# Enable PSRAM
+psram:
+  mode: octal
+  speed: 80MHz
+
+# --- Network -----------------------------------------------------------------
+# On-board W5500 over SPI. These pins are the board's wiring, not a preference.
+ethernet:
+  type: W5500
+  clk_pin: GPIO12
+  mosi_pin: GPIO11
+  miso_pin: GPIO13
+  cs_pin: GPIO10
+  interrupt_pin: GPIO9
+  reset_pin: GPIO48
+  clock_speed: 8MHz
+  # Uncomment for a fixed address (DHCP otherwise):
+  # manual_ip:
+  #   static_ip: 10.0.0.50
+  #   gateway: 10.0.0.1
+  #   subnet: 255.255.255.0
+
+# --- Tigo bus ----------------------------------------------------------------
+# The board's RS485 transceiver, on its own hardware UART. That leaves the USB
+# console free, so keep `logger:` on its defaults — do NOT set `baud_rate: 0`.
+uart:
+  id: tigo_uart
+  tx_pin: GPIO17
+  rx_pin: GPIO18
+  baud_rate: 38400
+  data_bits: 8
+  parity: NONE
+  stop_bits: 1
+  rx_buffer_size: 2048
+
+# --- Tigo Monitor ------------------------------------------------------------
+tigo_monitor:
+  id: tigo_hub
+  uart_id: tigo_uart
+  # Device and node tables live in PSRAM here, so this is cheap to raise —
+  # the contributor's install runs 64. Set it to your optimizer count.
+  number_of_devices: 30
+  update_interval: 30s
+
+# --- Web server --------------------------------------------------------------
+tigo_server:
+  id: tigo_web
+  tigo_monitor_id: tigo_hub
+  port: 80

--- a/boards/example-t-connect-pro-lite.yaml
+++ b/boards/example-t-connect-pro-lite.yaml
@@ -1,0 +1,130 @@
+# Example Tigo Monitor Configuration using the LilyGO T-Connect Pro Lite
+#
+# This is the "wired, full features" profile: web UI, REST API, on-flash
+# history, and Home Assistant over the native API — all over Ethernet.
+#
+# The hardware base (esp32s3-lilygo-t-connect-pro-lite.yaml) provides:
+#   - the ESP32-S3 / 8MB flash / 8MB PSRAM setup and the tsdb history storage
+#   - the on-board W5500 Ethernet controller
+#   - the UART on GPIO17/18, the tigo_monitor hub, and tigo_server
+# so this file only layers on credentials, sensors, and app config.
+#
+# There is deliberately no `wifi:` block — see the note in the board file.
+# Panel addresses come from the web UI once it is up (Nodes view), or from the
+# "Generate YAML Config" button below if you would rather work from the logs.
+
+packages:
+  board: !include esp32s3-lilygo-t-connect-pro-lite.yaml
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/RAR/esphome-tigomonitor
+      ref: main
+    components: [tigo_monitor, tigo_server]
+
+logger:
+  level: INFO  # Change to DEBUG if you need detailed logs for troubleshooting
+
+api:
+
+ota:
+  - platform: esphome
+    password: "YOUR_OTA_PASSWORD"
+    # Permits a later partition-table change over the air (ESPHome 2026.5.0+).
+    # It is only the permission: applying one still takes an explicit
+    # `esphome upload --partition-table`. A plain `esphome run` never sends a
+    # partition table, and succeeds without changing the layout.
+    allow_partition_access: true
+
+# Timestamps for the history database. Any time source works; SNTP needs no
+# Home Assistant connection.
+time:
+  - platform: sntp
+    id: sntp_time
+    timezone: "America/New_York"  # Adjust for your timezone
+
+button:
+  - platform: tigo_monitor
+    name: "Generate YAML Config"
+    id: generate_yaml_button
+    tigo_monitor_id: tigo_hub
+    button_type: yaml_generator
+  - platform: tigo_monitor
+    name: "Print Device Mappings"
+    id: device_mappings_button
+    tigo_monitor_id: tigo_hub
+    button_type: device_mappings
+  - platform: tigo_monitor
+    name: "Reset Node Table"
+    id: reset_node_table_button
+    tigo_monitor_id: tigo_hub
+    button_type: reset_node_table
+
+sensor:
+  # System-wide sensors — these need no addresses and work from first boot.
+  - platform: tigo_monitor
+    tigo_monitor_id: tigo_hub
+    name: "Total System Power"
+    id: total_system_power
+
+  - platform: tigo_monitor
+    tigo_monitor_id: tigo_hub
+    name: "Total System Energy"
+    id: total_system_energy
+
+  - platform: tigo_monitor
+    tigo_monitor_id: tigo_hub
+    name: "Active Device Count"
+
+  - platform: tigo_monitor
+    tigo_monitor_id: tigo_hub
+    name: "Missed Frame Count"
+
+  - platform: tigo_monitor
+    tigo_monitor_id: tigo_hub
+    name: "Free Internal RAM"
+
+  - platform: tigo_monitor
+    tigo_monitor_id: tigo_hub
+    name: "Free PSRAM"
+
+  - platform: uptime
+    name: "Tigo Server Uptime"
+
+  # Per-panel sensors go here. An entry needs `address:` AND at least one
+  # measurement sub-key — address and name alone create no entities:
+  #
+  # - platform: tigo_monitor
+  #   tigo_monitor_id: tigo_hub
+  #   address: "1234"
+  #   name: "Panel A1"
+  #   power: {}
+  #   voltage_in: {}
+  #   current_in: {}
+  #   temperature: {}
+
+text_sensor:
+  - platform: ethernet_info
+    ip_address:
+      name: "Tigo Server IP Address"
+      entity_category: diagnostic
+    mac_address:
+      name: "Tigo Server MAC Address"
+      entity_category: diagnostic
+
+  - platform: version
+    name: "Tigo Server ESPHome Version"
+
+binary_sensor:
+  - platform: status
+    name: "Tigo Server Status"
+
+  - platform: tigo_monitor
+    tigo_monitor_id: tigo_hub
+    night_mode:
+      name: "Solar Night Mode"
+
+switch:
+  - platform: restart
+    name: "Tigo Server Restart"

--- a/site/boards.js
+++ b/site/boards.js
@@ -363,6 +363,72 @@ font:
       'Tested at 18 devices; 40 should fit. Each optimizer costs roughly 600 bytes across the device and node tables, against the ~130KB free once WiFi is up — the practical ceiling is heap fragmentation, not total bytes.',
     ],
   },
+  {
+    id: 'esp32s3-lilygo-t-connect-pro-lite',
+    label: 'LilyGO T-Connect Pro Lite (ESP32-S3, 8MB PSRAM, wired Ethernet)',
+    chip: 'esp32s3', board: 'esp32-s3-devkitc-1', variant: 'esp32s3',
+    flash_size: '8MB',
+    // No `ble` variant: Bluetooth is compiled out below, so there is nothing
+    // for the larger app slots to hold.
+    partitions: { default: 'partitions/tigo-8mb.csv' },
+    psram: { mode: 'octal', speed: '80MHz' },
+    frameworkAdvanced: { enable_idf_experimental_features: false, execute_from_psram: true },
+    frameworkComponents: ['joltwallet/littlefs^1.16'],
+    hostedComponent: {
+      source: 'https://github.com/RAR/esp_tsdb.git',
+      ref: 'ebfc360f00263ab90116ee3e556a9153ab4041a2',
+    },
+    sdkconfig: {
+      CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240: 'y',
+      CONFIG_UART_ISR_IN_IRAM: 'y',
+      CONFIG_UART_RX_BUFFER_SIZE: '4096',
+      CONFIG_UART_TX_BUFFER_SIZE: '256',
+      CONFIG_FREERTOS_QUEUE_REGISTRY_SIZE: '32',
+      CONFIG_LOG_DEFAULT_LEVEL_INFO: 'y',
+      CONFIG_SPIRAM_MODE_OCT: 'y',
+      CONFIG_SPIRAM_SPEED_80M: 'y',
+      // Off, unlike the WiFi boards: that option moves the WiFi/lwIP buffer
+      // pool to PSRAM to spare internal RAM, and the radio is down here. The
+      // W5500 driver keeps its buffers internal either way.
+      CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP: 'n',
+      CONFIG_VFS_SUPPORT_DIR: 'y',
+      CONFIG_LWIP_MAX_SOCKETS: '16',
+      CONFIG_LWIP_MAX_ACTIVE_TCP: '16',
+      CONFIG_LWIP_MAX_LISTENING_TCP: '16',
+      // Dead weight on a wired board, and worth a large slice of flash.
+      CONFIG_BT_ENABLED: 'n',
+      CONFIG_BLUEDROID_ENABLED: 'n',
+      CONFIG_BT_BLE_42_FEATURES_SUPPORTED: 'n',
+      CONFIG_BT_BLE_50_FEATURES_SUPPORTED: 'n',
+    },
+    hosted: null,
+    // On-board W5500 over SPI. Present => the generator emits `ethernet:` and
+    // omits `wifi:`/`captive_portal:` entirely.
+    ethernet: {
+      type: 'W5500',
+      clk_pin: 'GPIO12',
+      mosi_pin: 'GPIO11',
+      miso_pin: 'GPIO13',
+      cs_pin: 'GPIO10',
+      interrupt_pin: 'GPIO9',
+      reset_pin: 'GPIO48',
+      clock_speed: '8MHz',
+    },
+    uartDefault: { tx_pin: 'GPIO17', rx_pin: 'GPIO18', rx_buffer_size: 2048 },
+    numberOfDevices: 30,
+    // BLE is compiled out, so the CCA-over-BLE bridge is not available here.
+    supports: { ble: false, display: false },
+    // The Tigo bus is on its own hardware UART, so the USB console stays.
+    keepSerialConsole: true,
+    gpioSwitches: null,
+    displayOverlay: null,
+    notes: [
+      'Wired Ethernet (W5500), no WiFi — the generated config has no `wifi:` block. Static addressing goes under `ethernet: manual_ip:`, so the Static IP field is hidden for this board.',
+      'Contributed from a working install (discussion #30). The pin map is the contributor’s; no maintainer unit exists to verify it against.',
+      'Bluetooth is compiled out to buy back flash, so CCA-over-BLE is unavailable. HTTP CCA import still works, and is unaffected by the wired link.',
+      'The screen-equipped "Pro" is a different board; this entry is the Lite and configures no display.',
+    ],
+  },
 ];
 
 export function getBoard(id) {

--- a/site/rules.js
+++ b/site/rules.js
@@ -31,10 +31,14 @@ export function assembleConfig(board, form) {
         }
       : null;
 
+  // Wired boards have no radio: the generated config carries an `ethernet:`
+  // block and no `wifi:`, so WiFi credentials are neither emitted nor written
+  // to secrets.yaml.
+  const ethernet = board.ethernet ?? null;
+
   const secrets = useSecrets
     ? {
-        wifi_ssid: form.wifi.ssid,
-        wifi_password: form.wifi.password,
+        ...(ethernet ? {} : { wifi_ssid: form.wifi.ssid, wifi_password: form.wifi.password }),
         api_encryption_key: form.apiKey,
         ota_password: form.otaPassword,
       }
@@ -59,12 +63,16 @@ export function assembleConfig(board, form) {
     partitions,
     psram: board.psram,
     hosted: board.hosted,
-    wifi: {
-      ssid: form.wifi.ssid,
-      password: form.wifi.password,
-      staticIp: form.wifi.staticIp || null,
-      useSecrets,
-    },
+    ethernet,
+    // null on a wired board — yaml.js then omits `wifi:` and `captive_portal:`.
+    wifi: ethernet
+      ? null
+      : {
+          ssid: form.wifi.ssid,
+          password: form.wifi.password,
+          staticIp: form.wifi.staticIp || null,
+          useSecrets,
+        },
     api: { useSecrets, key: form.apiKey },
     ota: { useSecrets, password: form.otaPassword },
     uart: {

--- a/site/src/components/ConfigWizard.astro
+++ b/site/src/components/ConfigWizard.astro
@@ -36,9 +36,14 @@
 
     <fieldset class="tw-card">
       <legend>Networking</legend>
-      <label class="field"><span>Wi-Fi SSID</span><input id="wifi-ssid" placeholder="YOUR_WIFI_SSID" /><small class="hint">Your home Wi-Fi network name, exactly as it appears.</small></label>
-      <label class="field"><span>Wi-Fi password</span><input id="wifi-pass" placeholder="YOUR_WIFI_PASSWORD" /></label>
-      <label class="field"><span>Static IP <em>(optional)</em></span><input id="static-ip" /><small class="hint">Leave blank and your router picks one. Fill it in if you want the dashboard always at the same address.</small></label>
+      <p class="notes" id="ethernet-note" style="display:none">
+        This board is wired — the generated config uses its on-board Ethernet
+        controller and has no Wi-Fi section. For a fixed address, uncomment the
+        <code>manual_ip:</code> block under <code>ethernet:</code>.
+      </p>
+      <label class="field" id="wifi-ssid-row"><span>Wi-Fi SSID</span><input id="wifi-ssid" placeholder="YOUR_WIFI_SSID" /><small class="hint">Your home Wi-Fi network name, exactly as it appears.</small></label>
+      <label class="field" id="wifi-pass-row"><span>Wi-Fi password</span><input id="wifi-pass" placeholder="YOUR_WIFI_PASSWORD" /></label>
+      <label class="field" id="static-ip-row"><span>Static IP <em>(optional)</em></span><input id="static-ip" /><small class="hint">Leave blank and your router picks one. Fill it in if you want the dashboard always at the same address.</small></label>
     </fieldset>
 
     <fieldset class="tw-card" id="cca-card">

--- a/site/test/drift.test.mjs
+++ b/site/test/drift.test.mjs
@@ -11,6 +11,7 @@ const FILE = {
   'esp32s3-atoms3r': 'boards/esp32s3-atoms3r.yaml',
   'esp32p4-evboard': 'boards/esp32p4-evboard.yaml',
   'esp32-lilygo-t-can485': 'boards/esp32-lilygo-t-can485.yaml',
+  'esp32s3-lilygo-t-connect-pro-lite': 'boards/esp32s3-lilygo-t-connect-pro-lite.yaml',
 };
 
 for (const [id, rel] of Object.entries(FILE)) {

--- a/site/test/yaml.test.mjs
+++ b/site/test/yaml.test.mjs
@@ -180,3 +180,26 @@ test('board sdkconfigBle is emitted only when the config selects BLE', () => {
   assert.ok(!toYaml(assembleConfig(getBoard('esp32s3-atoms3r'), bleForm)).includes(SYM),
     'boards without sdkconfigBle must be unaffected');
 });
+
+test('a wired board emits ethernet and no wifi at all', () => {
+  const b = getBoard('esp32s3-lilygo-t-connect-pro-lite');
+  // A static IP left in the form must not resurrect the wifi block either.
+  const y = toYaml(assembleConfig(b, {
+    ...form, uart: b.uartDefault, wifi: { ...form.wifi, staticIp: '10.0.0.50' },
+  }));
+  assert.ok(y.includes('\nethernet:'), 'ethernet block missing');
+  assert.ok(y.includes('type: W5500'), 'PHY type missing');
+  assert.ok(y.includes('cs_pin: GPIO10'), 'SPI pins missing');
+  // Both would compete for the same lwIP budget, and captive_portal is
+  // meaningless with no radio to fall back to.
+  assert.ok(!y.includes('\nwifi:'), 'wifi emitted on a wired board');
+  assert.ok(!y.includes('captive_portal'), 'captive_portal emitted on a wired board');
+});
+
+test('a wired board keeps wifi credentials out of secrets.yaml', () => {
+  const b = getBoard('esp32s3-lilygo-t-connect-pro-lite');
+  const s = toSecretsYaml(assembleConfig(b, { ...form, uart: b.uartDefault, useSecrets: true }));
+  assert.ok(s.includes('api_encryption_key:'), 'api key missing from secrets');
+  assert.ok(!s.includes('wifi_ssid'), 'wifi_ssid written for a board with no radio');
+  assert.ok(!s.includes('wifi_password'), 'wifi_password written for a board with no radio');
+});

--- a/site/wizard.js
+++ b/site/wizard.js
@@ -58,6 +58,15 @@ function syncBoardConstraints(board) {
   }
   $('no-server-note').style.display = webServer ? 'none' : '';
 
+  // Wired boards have no radio. Hide the WiFi fields rather than generating a
+  // config that quietly ignores them; static addressing on these goes under
+  // `ethernet: manual_ip:`, which the generated YAML carries as a comment.
+  const wired = Boolean(board.ethernet);
+  for (const id of ['wifi-ssid-row', 'wifi-pass-row', 'static-ip-row']) {
+    $(id).style.display = wired ? 'none' : '';
+  }
+  $('ethernet-note').style.display = wired ? '' : 'none';
+
   $('board-notes').textContent = board.notes.join(' ');
 }
 

--- a/site/yaml.js
+++ b/site/yaml.js
@@ -103,17 +103,35 @@ export function toYaml(cfg) {
     L.push('');
   }
 
-  // wifi
-  L.push('wifi:');
-  L.push(`${I(1)}ssid: ${val(cfg.wifi.useSecrets, 'wifi_ssid', cfg.wifi.ssid)}`);
-  L.push(`${I(1)}password: ${val(cfg.wifi.useSecrets, 'wifi_password', cfg.wifi.password)}`);
-  if (cfg.wifi.staticIp) {
-    L.push(`${I(1)}manual_ip:`);
-    L.push(`${I(2)}static_ip: ${cfg.wifi.staticIp}`);
+  // network — ethernet on boards with an on-board PHY, wifi otherwise. Never
+  // both: the two would compete for the same lwIP budget for no benefit, and
+  // captive_portal is meaningless without a radio to fall back to.
+  if (cfg.ethernet) {
+    const e = cfg.ethernet;
+    L.push('ethernet:');
+    L.push(`${I(1)}type: ${e.type}`);
+    for (const p of ['clk_pin', 'mosi_pin', 'miso_pin', 'cs_pin', 'interrupt_pin', 'reset_pin']) {
+      if (e[p]) L.push(`${I(1)}${p}: ${e[p]}`);
+    }
+    if (e.clock_speed) L.push(`${I(1)}clock_speed: ${e.clock_speed}`);
+    L.push(`${I(1)}# For a fixed address, uncomment and fill in:`);
+    L.push(`${I(1)}# manual_ip:`);
+    L.push(`${I(1)}#   static_ip: 10.0.0.50`);
+    L.push(`${I(1)}#   gateway: 10.0.0.1`);
+    L.push(`${I(1)}#   subnet: 255.255.255.0`);
+    L.push('');
+  } else {
+    L.push('wifi:');
+    L.push(`${I(1)}ssid: ${val(cfg.wifi.useSecrets, 'wifi_ssid', cfg.wifi.ssid)}`);
+    L.push(`${I(1)}password: ${val(cfg.wifi.useSecrets, 'wifi_password', cfg.wifi.password)}`);
+    if (cfg.wifi.staticIp) {
+      L.push(`${I(1)}manual_ip:`);
+      L.push(`${I(2)}static_ip: ${cfg.wifi.staticIp}`);
+    }
+    L.push('');
+    L.push('captive_portal:');
+    L.push('');
   }
-  L.push('');
-  L.push('captive_portal:');
-  L.push('');
 
   // logger
   L.push('logger:');


### PR DESCRIPTION
Closes the ask in [discussion #30](https://github.com/RAR/esphome-tigomonitor/discussions/30), where @davidcoulson posted a working config for this board and asked for it in the board list.

ESP32-S3, 8MB flash, 8MB octal PSRAM, on-board W5500 Ethernet, RS485 on GPIO17/18 — so it gets the full profile: web UI, on-flash history, and no WiFi.

## Board files

- `boards/esp32s3-lilygo-t-connect-pro-lite.yaml` — the hardware base to `!include`
- `boards/example-t-connect-pro-lite.yaml` — ready to flash

Stripped of the contributor's site-specific parts (their `packages:`, string labels, inverter names, and the four-LED status lambdas). The LED, button, relay, CAN and RS232 pins are documented in the board file without instantiating anything, with a pointer back to the discussion for the LED example.

Judgement calls:

- **No WiFi, deliberately.** The board file carries `ethernet:` and says not to add a `wifi:` block beside it — the radio would only split the lwIP socket budget.
- **Bluetooth compiled out**, as in the contributor's config. It buys back a large slice of flash and costs CCA-over-BLE; re-enabling means dropping the four `CONFIG_BT_*` lines *and* switching to `partitions/tigo-8mb-ble.csv`. HTTP CCA import is unaffected.
- **`number_of_devices: 30`** rather than their 64, which is their array size.
- **`board: esp32-s3-devkitc-1`** — the contributor specified only `variant`, which ESPHome no longer accepts alone.

## Config builder

Adding a wired board needed a wired path. A board that declares an `ethernet` PHY now emits an `ethernet:` block and omits `wifi:`/`captive_portal:` entirely, keeps WiFi credentials out of the generated `secrets.yaml`, and the wizard hides the WiFi fields behind a short explainer. Existing boards are unchanged.

## Verification

- The example compiles clean: flash 55.6% of the 1.75 MB slot, RAM 21.8%.
- The builder's generated config validates under `esphome config`.
- 49/49 site tests pass, including two new ones for the wired path; the new board is registered in the existing drift test, so its builder data cannot drift from the board file.
- Docs site builds clean, internal link validation passes.

**Not verified: the pin map.** There is no unit of this board here — the pins are the contributor's, and the board file and `boards/README.md` both say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
