### PR TITLE
docs(configuration): text sensors are sensor sub-keys, not a platform

### DIFF
--- a/site/src/content/docs/guides/configuration.md
+++ b/site/src/content/docs/guides/configuration.md
@@ -386,8 +386,13 @@ cards, each grouping the entities for its panels.
 
 ### Text Sensors
 
+A panel's barcode, firmware version and device info are text entities, but they
+are declared like every other measurement — as sub-keys of a **`sensor:`** entry.
+There is no `text_sensor:` platform for `tigo_monitor`; the component creates the
+text entities itself.
+
 ```yaml
-text_sensor:
+sensor:
   - platform: tigo_monitor
     tigo_monitor_id: tigo_hub
     address: "1234"
@@ -395,6 +400,19 @@ text_sensor:
     barcode: {}
     firmware_version: {}
     device_info: {}
+```
+
+They mix freely with the numeric sub-keys, so one entry per panel covers both:
+
+```yaml
+sensor:
+  - platform: tigo_monitor
+    tigo_monitor_id: tigo_hub
+    address: "1234"
+    name: "Panel 1"
+    power: {}
+    temperature: {}
+    barcode: {}
 ```
 
 ### Binary Sensors


### PR DESCRIPTION
The **Text Sensors** section of the configuration guide showed a block that cannot validate:

```yaml
text_sensor:
  - platform: tigo_monitor
    ...
```

There is no `text_sensor.py` in the component, so ESPHome fails with `Platform not found: 'text_sensor.tigo_monitor'`. `barcode` / `firmware_version` / `device_info` are sub-keys of a `sensor:` entry — `sensor.py` builds the text entities itself via `text_sensor.new_text_sensor()`.

Wrong since 2026-07-23. Noticed while answering #48, which was another case of the same underlying shape: per-panel entities come from sub-keys.

## Changes

`site/src/content/docs/guides/configuration.md` — the section now shows the correct form, says plainly that there is no `text_sensor:` platform for `tigo_monitor`, and adds an example mixing text and numeric sub-keys in one entry.

## Verification

Both forms run against `esphome config`:

- as documented → `Platform not found: 'text_sensor.tigo_monitor'`
- corrected → `Configuration is valid!`, and it mixes with `power: {}` / `temperature: {}`

Nothing else in the repo was affected. The other `text_sensor:` blocks are `wifi_info` / `ethernet_info` / `version` platforms in board files, the troubleshooting page's empty-stub advice is about `AUTO_LOAD` and still correct, and the "Generate YAML Config" button emits no `text_sensor:` block.

Docs site builds clean, internal link validation passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
